### PR TITLE
Use -nographics to reduce CPU usage

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,4 +28,4 @@ cd "$GAMEDIR"
 sh -c 'until [ "`netstat -ntl | tail -n+3`" ]; do sleep 1; done
 sleep 5 # gotta wait for it to open a logfile
 tail -F Logs/current.log ../Logs/*/*.log 2>/dev/null' &
-/opt/wine-staging/bin/wine ./EmpyrionDedicated.exe -batchmode -logFile Logs/current.log "$@" &> Logs/wine.log
+/opt/wine-staging/bin/wine ./EmpyrionDedicated.exe -batchmode -nographics -logFile Logs/current.log "$@" &> Logs/wine.log


### PR DESCRIPTION
Drawing to xvfb uses 60% of a CPU on a Ryzen 3xxx and 100% on Intel Ivy
Bridge. Without graphics, the CPU usage is negligible when idle.

It still seems to want a DISPLAY, so leave xvfb running.